### PR TITLE
Fix BAM-520 multiple unit tests

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -51,5 +51,6 @@ if __name__ == "__main__":
 
     # Test prompts for running specific tools! ##
     # prompt = "Run the test suite tool and report errors but do not fix them."
+    # prompt = "Return classes and methods that require additional testing."
 
     agent.run_agent(prompt)

--- a/demo.py
+++ b/demo.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     agent = UnitTestAgent(llm, conversational_memory)
 
     # Create a unit test and then attempt to fix the errors #
-    prompt = f"Create test classes as needed for each class and method reported by the test coverage tool. Use the local vector store to retrieve information on the method, its class and its package. If the vector store is empty, populate the vector store with code from the following directory '{args.data_path}'. Once created the test class should be saved to disk using an appropriate file name within `{args.data_path}`, and then tested. If there are any errors then attempt to fix them until resolved."
+    prompt = f"Create test classes for each class and method reported by the test coverage tool. Use the local vector store to retrieve information on the method, its class and its package. If the vector store is empty, populate the vector store with code from the following directory '{args.data_path}'. Once created the test class should be saved to disk using an appropriate file name within `{args.data_path}`, and then tested. If there are any errors then attempt to fix them until resolved."
 
     # A human in the loop prompt ##
     # prompt = f"Create one test class as needed for each method reported by the test coverage tool. Use the local vector store to retrieve information on the method, its class and its package as often as needed. If the vector store is empty, populate the vector store with code from the following directory '{args.data_path}'. Once created, the test class should be saved to disk using an appropriate file name, checked by a human, and then tested. If there are any errors then attempt to fix them with human input. "

--- a/demo.py
+++ b/demo.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     agent = UnitTestAgent(llm, conversational_memory)
 
     # Create a unit test and then attempt to fix the errors #
-    prompt = f"Create one test class as needed for each method reported by the test coverage tool. Use the local vector store to retrieve information on the method, its class and its package. If the vector store is empty, populate the vector store with code from the following directory '{args.data_path}'. Once created the test class should be saved to disk using an appropriate file name within `{args.data_path}`, and then tested. If there are any errors then attempt to fix them until resolved."
+    prompt = f"Create test classes as needed for each class and method reported by the test coverage tool. Use the local vector store to retrieve information on the method, its class and its package. If the vector store is empty, populate the vector store with code from the following directory '{args.data_path}'. Once created the test class should be saved to disk using an appropriate file name within `{args.data_path}`, and then tested. If there are any errors then attempt to fix them until resolved."
 
     # A human in the loop prompt ##
     # prompt = f"Create one test class as needed for each method reported by the test coverage tool. Use the local vector store to retrieve information on the method, its class and its package as often as needed. If the vector store is empty, populate the vector store with code from the following directory '{args.data_path}'. Once created, the test class should be saved to disk using an appropriate file name, checked by a human, and then tested. If there are any errors then attempt to fix them with human input. "

--- a/demo.py
+++ b/demo.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     agent = UnitTestAgent(llm, conversational_memory)
 
     # Create a unit test and then attempt to fix the errors #
-    prompt = f"Create test classes for each class and method reported by the test coverage tool. Use the local vector store to retrieve information on the method, its class and its package. If the vector store is empty, populate the vector store with code from the following directory '{args.data_path}'. Once created the test class should be saved to disk using an appropriate file name within `{args.data_path}`, and then tested. If there are any errors then attempt to fix them until resolved."
+    prompt = f"Create test classes for each class and method reported by the test coverage tool until no more are provided. Use the local vector store to retrieve information on the method, its class and its package. If the vector store is empty, populate the vector store with code from the following directory '{args.data_path}'. Once created the test class should be saved to disk using an appropriate file name within `{args.data_path}`, and then tested. If there are any errors then attempt to fix them until resolved."
 
     # A human in the loop prompt ##
     # prompt = f"Create one test class as needed for each method reported by the test coverage tool. Use the local vector store to retrieve information on the method, its class and its package as often as needed. If the vector store is empty, populate the vector store with code from the following directory '{args.data_path}'. Once created, the test class should be saved to disk using an appropriate file name, checked by a human, and then tested. If there are any errors then attempt to fix them with human input. "

--- a/src/unit_test_agent/tools.py
+++ b/src/unit_test_agent/tools.py
@@ -32,6 +32,36 @@ class DummyTestCoverage(BaseTool):
         raise NotImplementedError("This tool does not support async")
 
 
+class DummyTestCoverageMultiple(BaseTool):
+
+    name = "File Test Coverage Tool"
+    description = (
+        "use this tool to query for one method and class within the code base that requires "
+        "testing in JSON format. this tool is used multiple times until no more testing is "
+        "required."
+    )
+
+
+    returned_tests = list()
+
+    def __init__(self):
+        super().__init__()
+        self.returned_tests = [
+            '{ file: "fineract/fineract-client/src/main/java/org/apache/fineract/client/util/Calls.java", class: "Calls", method: "ok" }',
+            '{ file: "fineract/fineract-client/src/main/java/org/apache/fineract/client/util/Parts.java", class: "Parts", method: "fromFile" }'
+            ]
+
+    def _run(self):
+        if len(self.returned_tests) > 0:
+            print(f"Length of returned_tests : {len(self.returned_tests)}")
+            return self.returned_tests.pop()
+        else:
+            return 'No further unit tests required.'
+
+    def _arun(self):
+        raise NotImplementedError("This tool does not support async")
+
+
 class SaveToLocalFileSchema(BaseModel):
 
     file_path: str = FILE_PATH

--- a/src/unit_test_agent/tools.py
+++ b/src/unit_test_agent/tools.py
@@ -53,7 +53,6 @@ class DummyTestCoverageMultiple(BaseTool):
 
     def _run(self):
         if len(self.returned_tests) > 0:
-            print(f"Length of returned_tests : {len(self.returned_tests)}")
             return self.returned_tests.pop()
         else:
             return 'No further unit tests required.'

--- a/src/unit_test_agent/unit_test_agent.py
+++ b/src/unit_test_agent/unit_test_agent.py
@@ -10,6 +10,7 @@ from langchain.agents.agent import AgentExecutor
 from langchain.schema import BaseMemory
 from langchain.schema.language_model import BaseLanguageModel
 from src.unit_test_agent.tools import DummyTestCoverage
+from src.unit_test_agent.tools import DummyTestCoverageMultiple
 from src.unit_test_agent.tools import SaveToLocalFile
 from src.unit_test_agent.tools import RunTestSuiteTool
 from src.unit_test_agent.tools import ReadFromLocalFile
@@ -30,7 +31,7 @@ class UnitTestAgent():
         # TODO: This could also be passed into this class as a parameter, like `llm`, so maximum
         #       flexibility is achieved.
         agent_tools = load_tools(["human"], llm=llm)
-        agent_tools.append(DummyTestCoverage())
+        agent_tools.append(DummyTestCoverageMultiple())
         agent_tools.append(ConfirmVectorStoreCollectionIsEmpty())
         agent_tools.append(GetOrCreateVectorStore())
         agent_tools.append(SimilaritySearchVectorStore())
@@ -48,7 +49,7 @@ class UnitTestAgent():
             verbose=True,
             memory=conversational_memory,
             return_intermediate_step=True,
-            max_iterations=25
+            max_iterations=50
         )
 
     def run_agent(self, prompt: str):


### PR DESCRIPTION
Unit test agent now works with multiple tests (two) in the dummy test tool however, issues remain:
- Cucumber errors prevent the Agent from working with more than one unit test.
- Token Limit is also an issue if the test becomes larger (possibly solved using a different number of tokens in memory).

For now, committing the current branch to main as for demonstrations, the `demo.py` prompt can be changed to complete a single unit test when needed for clients.